### PR TITLE
Fix compiler warnings (unused var and type conversion).

### DIFF
--- a/AggregateHashTable.h
+++ b/AggregateHashTable.h
@@ -148,7 +148,7 @@ private:
 
     uint32_t hashGroup(std::vector<Value const*> const& group, size_t const groupSize) const
     {
-        size_t totalSize = 0;
+        uint32_t totalSize = 0;
         for(size_t i =0; i<groupSize; ++i)
         {
             totalSize += group[i]->size();
@@ -179,7 +179,7 @@ private:
     ArenaPtr                                 _arena;
     size_t const                             _groupSize;
     size_t const                             _numAggs;
-    size_t const                             _numHashBuckets;
+    uint32_t const                           _numHashBuckets;
     mgd::vector<HashTableEntry*>             _buckets;
     mgd::vector<Value>                       _values;
     Value const*                             _lastGroup;
@@ -246,7 +246,7 @@ public:
         _arena(arena),
         _groupSize(settings.getGroupSize()),
         _numAggs(settings.getNumAggs()),
-        _numHashBuckets(settings.getNumHashBuckets()),
+        _numHashBuckets(safe_static_cast<uint32_t>(settings.getNumHashBuckets())),
         _buckets(_arena, _numHashBuckets, NULL),
         _values(_arena, 0),
         _lastGroup(NULL),
@@ -264,6 +264,7 @@ public:
             accumulateStates(_lastState, input);
             return;
         }
+
         uint32_t hash = hashGroup(group, _groupSize) % _numHashBuckets;
         bool newGroup = true;
         bool newHash = true;

--- a/GroupedAggregateSettings.h
+++ b/GroupedAggregateSettings.h
@@ -107,8 +107,8 @@ static size_t chooseNumBuckets(size_t maxTableSize)
 class Settings
 {
 private:
-    size_t _groupSize;
-    size_t _numAggs;
+    uint32_t _groupSize;
+    uint32_t _numAggs;
     size_t _maxTableSize;
     bool   _maxTableSizeSet;
     size_t _spilloverChunkSize;
@@ -162,7 +162,6 @@ public:
             shared_ptr<OperatorParam> param = operatorParameters[i];
             if (param->getParamType() == PARAM_AGGREGATE_CALL)
             {
-                AttributeID inputAttId;
                 AttributeDesc inputAttDesc;
                 string outputAttName;
                 AggregatePtr agg = resolveAggregate((shared_ptr <OperatorParamAggregateCall> &) param, inputSchema.getAttributes(), &inputAttDesc, &outputAttName);
@@ -286,9 +285,6 @@ private:
 
     void setKeywordParamInt64(KeywordParameters const& kwParams, const char* const kw, bool& alreadySet, size_t& valueToSet)
     {
-        int64_t paramContent;
-        size_t numParams;
-
         if (!alreadySet) {
             Parameter kwParam = getKeywordParam(kwParams, kw);
             if (kwParam) {
@@ -402,7 +398,7 @@ private:
     }
 
 public:
-    size_t getGroupSize() const
+    uint32_t getGroupSize() const
     {
         return _groupSize;
     }
@@ -492,7 +488,7 @@ public:
         return _numHashBucketsSet;
     }
 
-    size_t getNumAggs() const
+    uint32_t getNumAggs() const
     {
         return _numAggs;
     }
@@ -507,7 +503,6 @@ public:
     ArrayDesc makeSchema(shared_ptr< Query> query, SchemaType const type, string const name = "") const
     {
         Attributes outputAttributes;
-        size_t i =0;
         if(type != FINAL)
         {
             outputAttributes.push_back( AttributeDesc("hash",   TID_UINT32,    0, CompressorType::NONE));

--- a/LogicalGroupedAggregate.cpp
+++ b/LogicalGroupedAggregate.cpp
@@ -80,7 +80,6 @@ public:
 
     ArrayDesc inferSchema(vector< ArrayDesc> schemas, shared_ptr< Query> query)
     {
-        size_t const numInstances = query->getInstancesCount();
         grouped_aggregate::Settings settings(schemas[0], _parameters, _kwParameters, query);
         return settings.makeSchema(query, Settings::FINAL, schemas[0].getName());
     }


### PR DESCRIPTION
Fix compiler warnings that show up while building in the SciDB build environment.
All warnings are unused variables and type conversion errors.
With this change, the plugin builds with 0 warnings in the SciDB build environment.
Tests run:
- SciDB plugin_tests (checkin and daily.stable.grouped_aggregate)
- grouped_aggregate/test.sh
All tests passed.